### PR TITLE
Ensure binary can be executed directly without specifying node

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const optimist = require('optimist')
 const createServer = require('./server')
 const { path, port } = optimist.usage('Usage: $0 --port [3842] --path [.]')


### PR DESCRIPTION
Without this change the following happens:

```
yarn global add mucher
yarn global v1.3.2
warning ../../package.json: No license field
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Installed "mucher@1.0.0" with binaries:
      - mucher
✨  Done in 21.20s.
➜  ~ mucher
/Users/Adam/.nave/installed/8.9.3/bin/mucher: line 1: syntax error near unexpected token `('
/Users/Adam/.nave/installed/8.9.3/bin/mucher: line 1: `const optimist = require('optimist')'
➜  ~
```